### PR TITLE
refactor: use dedicated supabase service

### DIFF
--- a/src/components/OrderForm.tsx
+++ b/src/components/OrderForm.tsx
@@ -1,7 +1,7 @@
 // src/components/OrderForm.tsx
 import React, { useEffect, useMemo, useState } from 'react';
 import { Plus, Minus, Trash2, Download, Mail } from 'lucide-react';
-import { supabase } from '../services/database';
+import { supabase } from '../services/supabase';
 import { PDFService } from './PDF';
 import { createOrderWithItems } from '../services/order';
 import { useAuth } from '../contexts/AuthContext';


### PR DESCRIPTION
## Summary
- import Supabase client from `services/supabase` in `OrderForm`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 37 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_689dad0b6b408329be66ebbbf922bbfe