### PR TITLE
Fix OrderForm export to match named imports

### DIFF
--- a/src/components/OrderForm.tsx
+++ b/src/components/OrderForm.tsx
@@ -34,7 +34,7 @@ type OrderRow = {
 
 const currency = (n: number) => `R ${n.toFixed(2)}`;
 
-export default function OrderForm() {
+export function OrderForm() {
   const { currentRep } = useAuth();
   const [clients, setClients] = useState<Client[]>([]);
   const [products, setProducts] = useState<Product[]>([]);


### PR DESCRIPTION
## Summary
- export OrderForm as a named component instead of default

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db375728c8329a334488e7e0d62f7