### PR TITLE
Auto-link orders to active visit client

### DIFF
--- a/src/services/order.ts
+++ b/src/services/order.ts
@@ -10,6 +10,7 @@ export interface OrderLineForRPC {
 export async function createOrderWithItems(params: {
   clientId: string;
   repId: string;
+  visitId?: string;
   isFree: boolean;
   discountPercent: number;
   discountReason?: string | null;
@@ -20,6 +21,7 @@ export async function createOrderWithItems(params: {
   const { data, error } = await supabase.rpc('create_order_with_items', {
     p_client_id: params.clientId,
     p_rep_id: params.repId,
+    p_visit_id: params.visitId ?? null,
     p_is_free: params.isFree,
     p_discount_percent: params.discountPercent,
     p_discount_reason: params.discountReason ?? null,


### PR DESCRIPTION
## Summary
- Allow `OrderForm` to accept a preset client and optional visit, skipping client search when supplied
- Pass visit id through `createOrderWithItems` so orders link to the active visit

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 37 errors, 1 warning)

------
https://chatgpt.com/codex/tasks/task_e_689db621688083298f8bb83a930d87df